### PR TITLE
civitoken.php: avoid fatal error if declare function returns null

### DIFF
--- a/civitoken.php
+++ b/civitoken.php
@@ -75,7 +75,7 @@ function civitoken_civicrm_tokens_all(&$tokens) {
   $civitokens = [];
   foreach ($tokenFunctions as $token) {
     $fn = $token . '_civitoken_declare';
-    $tokens[$token] = array_merge($civitokens, $fn($token));
+    $tokens[$token] = array_merge($civitokens, $fn($token) ?? []);
   }
   $tokens['civitokens'] = $civitokens;
 }


### PR DESCRIPTION
Hi Eileen. It might not have occurred to you that the “declare” function in an .inc file might not return anything. I have created files like this to make shared helper functions available to several other files containing “true” token code. The declare function in this helper file had an empty body, so effectively it would return NULL. Up to PHP 7.4, array_merge would issue a warning if its second argument is NULL, starting with PHP 8 a fatal error is created. I would propose to tolerate a return value of NULL and this small change should take care of it. What do you think?